### PR TITLE
Rename "verify" functions to "jwtVerify" and don't undefine verify macro

### DIFF
--- a/Source/JWTPlugin/Private/JWTVerifier.cpp
+++ b/Source/JWTPlugin/Private/JWTVerifier.cpp
@@ -25,7 +25,7 @@ void UJWTVerifier::SetAlgorithm(const FString& Key, EAlgorithm Algorithm) {
 
 bool UJWTVerifier::VerifyJWT(const FString& Input) {
 	try {
-		 Verifier.verify(jwt::decode(TCHAR_TO_ANSI(*Input)));
+		 Verifier.jwtVerify(jwt::decode(TCHAR_TO_ANSI(*Input)));
 	}
 	catch (const std::exception& ec) {
 		UE_LOG(LogTemp, Error, TEXT("Error:  %d"), *ec.what());

--- a/Source/JWTPlugin/Public/JWTVerifier.h
+++ b/Source/JWTPlugin/Public/JWTVerifier.h
@@ -6,10 +6,6 @@
 #include "CoreMinimal.h"
 #include "JWTVerifier.generated.h"
 
-#ifdef verify
-#undef verify//assertion macros in ue4
-#endif
-
 UCLASS(BlueprintType)
 class JWTPLUGIN_API UJWTVerifier : public UObject
 {
@@ -40,5 +36,5 @@ public:
 	UFUNCTION(BlueprintCallable, meta = (DisplayName = "Verify JWT", Keywords = "JWT"), Category = "JWT")
 	bool VerifyJWT(const FString& Input);
 private:
-    jwt::verifier<jwt::default_clock,jwt::picojson_traits> Verifier = jwt::verify();
+    jwt::verifier<jwt::default_clock,jwt::picojson_traits> Verifier = jwt::jwtVerify();
 };

--- a/Source/JWTPlugin/ThirdParty/jwt-cpp/jwt.h
+++ b/Source/JWTPlugin/ThirdParty/jwt-cpp/jwt.h
@@ -19,9 +19,6 @@
 #include <openssl/ec.h>
 #include <openssl/err.h>
 #undef UI
-#ifdef verify
-#undef verify//assertion macros in ue4
-#endif
 
 
 #include <algorithm>
@@ -684,7 +681,7 @@ namespace jwt {
 			 * \param signature Signature data to verify
 			 * \param ec		error_code filled with details about the error
 			 */
-			void verify(const std::string& /*unused*/, const std::string& signature, std::error_code& ec) const {
+			void jwtVerify(const std::string& /*unused*/, const std::string& signature, std::error_code& ec) const {
 				ec.clear();
 				if (!signature.empty()) { ec = error::signature_verification_error::invalid_signature; }
 			}
@@ -729,7 +726,7 @@ namespace jwt {
 			 * \param signature Signature provided by the jwt
 			 * \param ec Filled with details about failure.
 			 */
-			void verify(const std::string& data, const std::string& signature, std::error_code& ec) const {
+			void jwtVerify(const std::string& data, const std::string& signature, std::error_code& ec) const {
 				ec.clear();
 				auto res = sign(data, ec);
 				if (ec) return;
@@ -823,7 +820,7 @@ namespace jwt {
 			 * \param signature Signature provided by the jwt
 			 * \param ec Filled with details on failure
 			 */
-			void verify(const std::string& data, const std::string& signature, std::error_code& ec) const {
+			void jwtVerify(const std::string& data, const std::string& signature, std::error_code& ec) const {
 				ec.clear();
 #ifdef OPENSSL10
 				std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_destroy)> ctx(EVP_MD_CTX_create(), EVP_MD_CTX_destroy);
@@ -966,7 +963,7 @@ namespace jwt {
 			 * \param signature Signature provided by the jwt
 			 * \param ec Filled with details on error
 			 */
-			void verify(const std::string& data, const std::string& signature, std::error_code& ec) const {
+			void jwtVerify(const std::string& data, const std::string& signature, std::error_code& ec) const {
 				ec.clear();
 				const std::string hash = generate_hash(data, ec);
 				if (ec) return;
@@ -1137,7 +1134,7 @@ namespace jwt {
 			 * \param signature Signature provided by the jwt
 			 * \param ec Filled with details on error
 			 */
-			void verify(const std::string& data, const std::string& signature, std::error_code& ec) const {
+			void jwtVerify(const std::string& data, const std::string& signature, std::error_code& ec) const {
 				ec.clear();
 				std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)> ctx(EVP_MD_CTX_create(), EVP_MD_CTX_free);
 				if (!ctx) {
@@ -1251,7 +1248,7 @@ namespace jwt {
 			 * \param signature Signature provided by the jwt
 			 * \param ec Filled with error details
 			 */
-			void verify(const std::string& data, const std::string& signature, std::error_code& ec) const {
+			void jwtVerify(const std::string& data, const std::string& signature, std::error_code& ec) const {
 				ec.clear();
 				auto hash = this->generate_hash(data, ec);
 				if (ec) return;
@@ -2620,14 +2617,14 @@ namespace jwt {
 	class verifier {
 		struct algo_base {
 			virtual ~algo_base() = default;
-			virtual void verify(const std::string& data, const std::string& sig, std::error_code& ec) = 0;
+			virtual void jwtVerify(const std::string& data, const std::string& sig, std::error_code& ec) = 0;
 		};
 		template<typename T>
 		struct algo : public algo_base {
 			T alg;
 			explicit algo(T a) : alg(a) {}
-			void verify(const std::string& data, const std::string& sig, std::error_code& ec) override {
-				alg.verify(data, sig, ec);
+			void jwtVerify(const std::string& data, const std::string& sig, std::error_code& ec) override {
+				alg.jwtVerify(data, sig, ec);
 			}
 		};
 
@@ -2757,9 +2754,9 @@ namespace jwt {
 		 * \param jwt Token to check
 		 * \throw token_verification_exception Verification failed
 		 */
-		void verify(const decoded_jwt<json_traits>& jwt) const {
+		void jwtVerify(const decoded_jwt<json_traits>& jwt) const {
 			std::error_code ec;
-			verify(jwt, ec);
+			jwtVerify(jwt, ec);
 			error::throw_if_error(ec);
 		}
 		/**
@@ -2767,7 +2764,7 @@ namespace jwt {
 		 * \param jwt Token to check
 		 * \param ec error_code filled with details on error
 		 */
-		void verify(const decoded_jwt<json_traits>& jwt, std::error_code& ec) const {
+		void jwtVerify(const decoded_jwt<json_traits>& jwt, std::error_code& ec) const {
 			ec.clear();
 			const typename json_traits::string_type data = jwt.get_header_base64() + "." + jwt.get_payload_base64();
 			const typename json_traits::string_type sig = jwt.get_signature();
@@ -2776,7 +2773,7 @@ namespace jwt {
 				ec = error::token_verification_error::wrong_algorithm;
 				return;
 			}
-			algs.at(algo)->verify(data, sig, ec);
+			algs.at(algo)->jwtVerify(data, sig, ec);
 			if (ec) return;
 
 			auto assert_claim_eq = [](const decoded_jwt<json_traits>& jwt, const typename json_traits::string_type& key,
@@ -2890,7 +2887,7 @@ namespace jwt {
 	 * \return verifier instance
 	 */
 	template<typename Clock, typename json_traits>
-	verifier<Clock, json_traits> verify(Clock c) {
+	verifier<Clock, json_traits> jwtVerify(Clock c) {
 		return verifier<Clock, json_traits>(c);
 	}
 
@@ -3003,8 +3000,8 @@ namespace jwt {
 	 * Create a verifier using the default clock
 	 * \return verifier instance
 	 */
-	inline verifier<default_clock, picojson_traits> verify() {
-		return verify<default_clock, picojson_traits>(default_clock{});
+	inline verifier<default_clock, picojson_traits> jwtVerify() {
+		return jwtVerify<default_clock, picojson_traits>(default_clock{});
 	}
 	/**
 	 * Return a picojson builder instance to create a new token


### PR DESCRIPTION
This should make this plugin compatible with the "verify" macro provided by Unreal Engine.